### PR TITLE
Set non-empty default values for query parameters with default values

### DIFF
--- a/source/Tubeshade.Server/Pages/Downloads/IDownloadPage.cs
+++ b/source/Tubeshade.Server/Pages/Downloads/IDownloadPage.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
 using Tubeshade.Data.Media;
 using Tubeshade.Server.Pages.Shared;
 using Tubeshade.Server.Pages.Videos;
@@ -31,13 +32,32 @@ public interface IDownloadPage : IPaginatedDataPage<VideoModel>
         { nameof(Query), Query },
         { nameof(ChannelId), ChannelId?.ToString() },
         { nameof(Type), Type?.Name },
-        { nameof(WithFiles), WithFiles?.ToString() },
+        { nameof(WithFiles), WithFiles?.ToString() ?? " " },
         { nameof(Availability), Availability?.Name },
-        { nameof(SortBy), SortBy?.Name },
-        { nameof(SortDirection), SortDirection?.Name },
+        { nameof(SortBy), SortBy?.Name ?? " " },
+        { nameof(SortDirection), SortDirection?.Name ?? " " },
         { nameof(PageSize), PageSize?.ToString() },
         { nameof(PageIndex), pageIndex.ToString() },
     };
+
+    void ApplyDefaultFilters<TPage>(TPage page)
+        where TPage : PageModel, IDownloadPage
+    {
+        if (page.WithFiles is null && !page.Request.Query.ContainsKey(nameof(page.WithFiles)))
+        {
+            page.WithFiles = true;
+        }
+
+        if (page.SortBy is null && !page.Request.Query.ContainsKey(nameof(page.SortBy)))
+        {
+            page.SortBy = Defaults.VideoOrder;
+        }
+
+        if (page.SortDirection is null && !page.Request.Query.ContainsKey(nameof(page.SortDirection)))
+        {
+            page.SortDirection = Defaults.SortDirection;
+        }
+    }
 
     Task<IActionResult> OnPostStartDownload(Guid videoId);
 

--- a/source/Tubeshade.Server/Pages/Downloads/PageModelExtensions.cs
+++ b/source/Tubeshade.Server/Pages/Downloads/PageModelExtensions.cs
@@ -14,7 +14,7 @@ public static class PageModelExtensions
         Guid? channelId)
         where TPage : PageModel, IDownloadPage
     {
-        pageModel.ApplyDefaultFilters();
+        pageModel.ApplyDefaultFilters(pageModel);
 
         var pageSize = pageModel.PageSize ?? Defaults.PageSize;
         var page = pageModel.PageIndex ?? Defaults.PageIndex;
@@ -34,24 +34,5 @@ public static class PageModelExtensions
             SortBy = pageModel.SortBy ?? Defaults.VideoOrder,
             SortDirection = pageModel.SortDirection ?? Defaults.SortDirection,
         };
-    }
-
-    private static void ApplyDefaultFilters<TPage>(this TPage page)
-        where TPage : PageModel, IDownloadPage
-    {
-        if (page.WithFiles is null && !page.Request.Query.ContainsKey(nameof(page.WithFiles)))
-        {
-            page.WithFiles = true;
-        }
-
-        if (page.SortBy is null && !page.Request.Query.ContainsKey(nameof(page.SortBy)))
-        {
-            page.SortBy = Defaults.VideoOrder;
-        }
-
-        if (page.SortDirection is null && !page.Request.Query.ContainsKey(nameof(page.SortDirection)))
-        {
-            page.SortDirection = Defaults.SortDirection;
-        }
     }
 }

--- a/source/Tubeshade.Server/Pages/Videos/IVideoPage.cs
+++ b/source/Tubeshade.Server/Pages/Videos/IVideoPage.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
 using Tubeshade.Data.Media;
 using Tubeshade.Server.Pages.Shared;
 
@@ -26,15 +27,39 @@ public interface IVideoPage : IPaginatedDataPage<VideoModel>
     Dictionary<string, string?> GetRouteValues(int pageIndex) => new()
     {
         { nameof(Query), Query },
-        { nameof(Viewed), Viewed?.ToString() },
+        { nameof(Viewed), Viewed?.ToString() ?? " " },
         { nameof(Type), Type?.Name },
-        { nameof(WithFiles), WithFiles?.ToString() },
+        { nameof(WithFiles), WithFiles?.ToString() ?? " " },
         { nameof(Availability), Availability?.Name },
-        { nameof(SortBy), SortBy?.Name },
-        { nameof(SortDirection), SortDirection?.Name },
+        { nameof(SortBy), SortBy?.Name ?? " " },
+        { nameof(SortDirection), SortDirection?.Name ?? " " },
         { nameof(PageSize), PageSize?.ToString() },
         { nameof(PageIndex), $"{pageIndex}" },
     };
+
+    void ApplyDefaultFilters<TPage>(TPage page)
+        where TPage : PageModel, IVideoPage
+    {
+        if (page.WithFiles is null && !page.Request.Query.ContainsKey(nameof(page.WithFiles)))
+        {
+            page.WithFiles = true;
+        }
+
+        if (page.Viewed is null && !page.Request.Query.ContainsKey(nameof(page.Viewed)))
+        {
+            page.Viewed = false;
+        }
+
+        if (page.SortBy is null && !page.Request.Query.ContainsKey(nameof(page.SortBy)))
+        {
+            page.SortBy = Defaults.VideoOrder;
+        }
+
+        if (page.SortDirection is null && !page.Request.Query.ContainsKey(nameof(page.SortDirection)))
+        {
+            page.SortDirection = Defaults.SortDirection;
+        }
+    }
 
     Task<IActionResult> OnPostViewed(string? viewed, Guid videoId);
 }

--- a/source/Tubeshade.Server/Pages/Videos/PageModelExtensions.cs
+++ b/source/Tubeshade.Server/Pages/Videos/PageModelExtensions.cs
@@ -14,7 +14,7 @@ public static class PageModelExtensions
         Guid? channelId)
         where TPage : PageModel, IVideoPage
     {
-        pageModel.ApplyDefaultFilters();
+        pageModel.ApplyDefaultFilters(pageModel);
 
         var pageSize = pageModel.PageSize ?? Defaults.PageSize;
         var page = pageModel.PageIndex ?? Defaults.PageIndex;
@@ -35,29 +35,5 @@ public static class PageModelExtensions
             SortBy = pageModel.SortBy ?? Defaults.VideoOrder,
             SortDirection = pageModel.SortDirection ?? Defaults.SortDirection,
         };
-    }
-
-    private static void ApplyDefaultFilters<TPage>(this TPage page)
-        where TPage : PageModel, IVideoPage
-    {
-        if (page.WithFiles is null && !page.Request.Query.ContainsKey(nameof(page.WithFiles)))
-        {
-            page.WithFiles = true;
-        }
-
-        if (page.Viewed is null && !page.Request.Query.ContainsKey(nameof(page.Viewed)))
-        {
-            page.Viewed = false;
-        }
-
-        if (page.SortBy is null && !page.Request.Query.ContainsKey(nameof(page.SortBy)))
-        {
-            page.SortBy = Defaults.VideoOrder;
-        }
-
-        if (page.SortDirection is null && !page.Request.Query.ContainsKey(nameof(page.SortDirection)))
-        {
-            page.SortDirection = Defaults.SortDirection;
-        }
     }
 }


### PR DESCRIPTION
﻿Fixes #204

Changes proposed in this pull request:
* Apply non-empty strings as default values so that query parameters are included in link generation
