### PR TITLE
Index livestreams while they are live

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,11 @@ _Latest build from master branch._
 - Task run source tracking
   ([#174](https://github.com/Tubeshade/Tubeshade/issues/174))
 
+### Changed
+
+- Index livestreams while they are live
+  ([#176](https://github.com/Tubeshade/Tubeshade/issues/176))
+
 ### Fixed
 
 - Skip overlapping Sponsor Block segments

--- a/source/Tubeshade.Data/Media/VideoEntity.cs
+++ b/source/Tubeshade.Data/Media/VideoEntity.cs
@@ -38,7 +38,7 @@ public sealed record VideoEntity : ModifiableEntity, IOwnableEntity, INamedEntit
 
     public required ExternalAvailability Availability { get; set; }
 
-    public required Period Duration { get; set; }
+    public required Period? Duration { get; set; }
 
     public Instant? IgnoredAt { get; set; }
 

--- a/source/Tubeshade.Data/Migrations/000040_optional-duration.sql
+++ b/source/Tubeshade.Data/Migrations/000040_optional-duration.sql
@@ -1,0 +1,2 @@
+﻿ALTER TABLE media.videos
+    ALTER column duration DROP NOT NULL;

--- a/source/Tubeshade.Server/Pages/Downloads/_VideoCard.cshtml
+++ b/source/Tubeshade.Server/Pages/Downloads/_VideoCard.cshtml
@@ -25,11 +25,14 @@
                         <time datetime="@InstantPattern.General.Format(Model.Video.PublishedAt)">
                             @LocalDatePattern.Iso.Format(Model.Video.PublishedAt.InUtc().Date)
                         </time>
-                        <span> - </span>
-                        <span>@(HumanReadablePeriodPattern.Instance.Format(Model.Video.Duration))</span>
-                        @if (Model.Video.Duration != Model.ActualDuration)
+                        @if (Model is { ActualDuration: { } actualDuration, Video.Duration: { } duration })
                         {
-                            <span>(@(HumanReadablePeriodPattern.Instance.Format(Model.ActualDuration)))</span>
+                            <span> - </span>
+                            <span>@(HumanReadablePeriodPattern.Instance.Format(duration))</span>
+                            @if (duration != actualDuration)
+                            {
+                                <span>(@(HumanReadablePeriodPattern.Instance.Format(actualDuration)))</span>
+                            }
                         }
                     </div>
 

--- a/source/Tubeshade.Server/Pages/Libraries/Channels/Channel.cshtml.cs
+++ b/source/Tubeshade.Server/Pages/Libraries/Channels/Channel.cshtml.cs
@@ -6,7 +6,6 @@ using Htmx;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Npgsql;
-using SponsorBlock;
 using Tubeshade.Data;
 using Tubeshade.Data.Media;
 using Tubeshade.Server.Configuration.Auth;
@@ -96,21 +95,7 @@ public sealed class Channel : LibraryPageBase, IVideoPage, IPageWithSettings
         var videoIds = videos.Select(video => video.Id).ToArray();
         var segments = await _segmentRepository.GetForVideos(videoIds, userId, cancellationToken);
 
-        var models = videos.Select(video =>
-        {
-            var skippedDuration = segments
-                .Where(segment => segment.VideoId == video.Id && segment.Category != SegmentCategory.Filler)
-                .GetTotalDuration();
-
-            var actualDuration = (video.Duration - skippedDuration).Normalize();
-
-            return new VideoModel
-            {
-                Video = video,
-                ActualDuration = actualDuration,
-                Channel = channels.Single(channel => video.ChannelId == channel.Id), // todo
-            };
-        }).ToList();
+        var models = videos.MapToModels(segments, channels).ToList();
 
         var totalCount = videos is [] ? 0 : videos[0].TotalCount;
 

--- a/source/Tubeshade.Server/Pages/Libraries/Library.cshtml.cs
+++ b/source/Tubeshade.Server/Pages/Libraries/Library.cshtml.cs
@@ -6,7 +6,6 @@ using Htmx;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Npgsql;
-using SponsorBlock;
 using Tubeshade.Data;
 using Tubeshade.Data.Media;
 using Tubeshade.Server.Configuration.Auth;
@@ -91,21 +90,7 @@ public sealed class Library : LibraryPageBase, IVideoPage, IPageWithSettings
         var videoIds = videos.Select(video => video.Id).ToArray();
         var segments = await _segmentRepository.GetForVideos(videoIds, userId, cancellationToken);
 
-        var models = videos.Select(video =>
-        {
-            var skippedDuration = segments
-                .Where(segment => segment.VideoId == video.Id && segment.Category != SegmentCategory.Filler)
-                .GetTotalDuration();
-
-            var actualDuration = (video.Duration - skippedDuration).Normalize();
-
-            return new VideoModel
-            {
-                Video = video,
-                ActualDuration = actualDuration,
-                Channel = channels.Single(channel => video.ChannelId == channel.Id), // todo
-            };
-        }).ToList();
+        var models = videos.MapToModels(segments, channels).ToList();
 
         var totalCount = videos is [] ? 0 : videos[0].TotalCount;
 

--- a/source/Tubeshade.Server/Pages/Videos/VideoModel.cs
+++ b/source/Tubeshade.Server/Pages/Videos/VideoModel.cs
@@ -7,11 +7,11 @@ public sealed class VideoModel
 {
     public required VideoEntity Video { get; init; }
 
-    public required Period ActualDuration { get; init; }
+    public required Period? ActualDuration { get; init; }
 
     public required ChannelEntity Channel { get; init; }
 
     public bool Viewed => Video.Viewed is true;
 
-    public double DurationInSeconds => Video.Duration.ToDuration().TotalSeconds;
+    public double? DurationInSeconds => Video.Duration?.ToDuration().TotalSeconds;
 }

--- a/source/Tubeshade.Server/Pages/Videos/_Videos.cshtml
+++ b/source/Tubeshade.Server/Pages/Videos/_Videos.cshtml
@@ -14,11 +14,11 @@
                          loading="lazy" alt="@video.Video.Name" title="@video.Video.Name"
                          class="card-img-top tubeshade-video-thumbnail"/>
                 </a>
-                @if (video.Video.Position is { } position &&
-                     Math.Abs(video.DurationInSeconds - position) > Defaults.PlaybackEpsilon &&
+                @if (video is { DurationInSeconds: { } durationInSeconds, Video.Position: { } position } &&
+                     Math.Abs(durationInSeconds - position) > Defaults.PlaybackEpsilon &&
                      position > Defaults.PlaybackEpsilon)
                 {
-                    <progress max="@video.DurationInSeconds.ToString(CultureInfo.InvariantCulture)"
+                    <progress max="@durationInSeconds.ToString(CultureInfo.InvariantCulture)"
                               value="@position.ToString(CultureInfo.InvariantCulture)"
                               class="position-absolute w-100" style="transform: translate(0,-50%)">
                     </progress>
@@ -51,10 +51,13 @@
                         @LocalDatePattern.Iso.Format(video.Video.PublishedAt.InUtc().Date)
                     </time>
                     <div>
-                        <span>@(HumanReadablePeriodPattern.Instance.Format(video.Video.Duration))</span>
-                        @if (video.Video.Duration != video.ActualDuration)
+                        @if (video is { ActualDuration: { } actualDuration, Video.Duration: { } duration })
                         {
-                            <span>(@(HumanReadablePeriodPattern.Instance.Format(video.ActualDuration)))</span>
+                            <span>@(HumanReadablePeriodPattern.Instance.Format(duration))</span>
+                            @if (duration != actualDuration)
+                            {
+                                <span>(@(HumanReadablePeriodPattern.Instance.Format(actualDuration)))</span>
+                            }
                         }
                     </div>
                 </div>

--- a/source/Tubeshade.Server/Services/LoggerExtensions.cs
+++ b/source/Tubeshade.Server/Services/LoggerExtensions.cs
@@ -246,4 +246,7 @@ internal static partial class LoggerExtensions
 
     [LoggerMessage(76, Information, "Queuing notification {NotificationChannel} {TaskId} {TaskSource}")]
     internal static partial void QueueingNotification(this ILogger logger, string notificationChannel, Guid taskId, string taskSource);
+
+    [LoggerMessage(77, Debug, "Video {VideoId} is still live, not downloading")]
+    internal static partial void NotDownloadingLiveVideo(this ILogger logger, Guid videoId);
 }

--- a/source/Tubeshade.Server/Services/StringExtensions.cs
+++ b/source/Tubeshade.Server/Services/StringExtensions.cs
@@ -17,12 +17,12 @@ public static partial class StringExtensions
 
     public static bool TryExtractChapters(
         [NotNullWhen(true)] this string? description,
-        Period videoDuration,
+        Period? videoDuration,
         [MaybeNullWhen(false)] out TextTrackCue[] chapters)
     {
         chapters = null;
 
-        if (string.IsNullOrWhiteSpace(description))
+        if (string.IsNullOrWhiteSpace(description) || videoDuration is null)
         {
             return false;
         }

--- a/source/Tubeshade.Server/Services/VideoService.cs
+++ b/source/Tubeshade.Server/Services/VideoService.cs
@@ -30,7 +30,7 @@ public sealed class VideoService
         Instant publishedAt,
         Instant refreshedAt,
         ExternalAvailability availability,
-        Period duration,
+        Period? duration,
         long? views,
         long? likes,
         NpgsqlTransaction transaction)

--- a/tests/Tubeshade.Server.Tests.Integration/Media/ImageFileRepositoryTests.cs
+++ b/tests/Tubeshade.Server.Tests.Integration/Media/ImageFileRepositoryTests.cs
@@ -73,7 +73,7 @@ public sealed class ImageFileRepositoryTests(ServerFixture fixture) : ServerTest
                     PublishedAt = SystemClock.Instance.GetCurrentInstant(),
                     RefreshedAt = SystemClock.Instance.GetCurrentInstant(),
                     Availability = ExternalAvailability.Public,
-                    Duration = Period.Zero,
+                    Duration = Period.FromMinutes(10),
                     TotalCount = 0
                 },
                 transaction))!.Value;


### PR DESCRIPTION
Work towards #176

Changes proposed in this pull request:
* Make duration optional for videos
* Index livestreams while they are still live/upcoming, and download once the VOD is ready
