### PR TITLE
Treat videos shorter than 20 seconds of unknown type as shorts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,8 @@ _Latest build from master branch._
   ([#247](https://github.com/Tubeshade/Tubeshade/pull/247))
 - Ignore formats with lower framerate than downloaded videos
   ([#249](https://github.com/Tubeshade/Tubeshade/pull/249))
+- Treat videos shorter than 20 seconds of unknown type as shorts
+  ([#250](https://github.com/Tubeshade/Tubeshade/pull/250))
 
 ## [0.1.4] - 2026-02-22
 

--- a/source/Tubeshade.Server/Services/YoutubeService.cs
+++ b/source/Tubeshade.Server/Services/YoutubeService.cs
@@ -226,6 +226,7 @@ public sealed class YoutubeService
         type ??= videoData switch
         {
             { LiveStatus: not (LiveStatus.None or LiveStatus.NotLive) } => VideoType.Livestream,
+            { Duration: < 20 } => VideoType.Short,
             _ => VideoType.Video,
         };
 


### PR DESCRIPTION
Some (?) YouTube posts are actually 15 second videos of a static image, and also generate new/modified video events. In the browser the watch URL redirects to a post, however that does not show up in yt-dlp