### PR TITLE
Ignore no format errors when indexing videos

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,8 @@ _Latest build from master branch._
   ([#284](https://github.com/Tubeshade/Tubeshade/pull/284))
 - Update yt-dlp from 2026.03.17 to 2026.06.09
   ([#284](https://github.com/Tubeshade/Tubeshade/pull/284))
+- Ignore no format errors when indexing videos
+  ([#285](https://github.com/Tubeshade/Tubeshade/pull/285))
 
 ## [0.1.6] - 2026-04-24
 

--- a/source/Tubeshade.Server/Services/IYtdlpWrapper.cs
+++ b/source/Tubeshade.Server/Services/IYtdlpWrapper.cs
@@ -32,10 +32,10 @@ public interface IYtdlpWrapper
         string format,
         string? cookieFilepath,
         PlayerClient? client,
-        bool ignoreNoFormatsError,
         CancellationToken cancellationToken);
 
-    ValueTask<FormatData[][]> SelectFormats(string videoUrl,
+    ValueTask<FormatData[][]> SelectFormats(
+        string videoUrl,
         IEnumerable<string> formats,
         string? cookieFilepath,
         PlayerClient? client,

--- a/source/Tubeshade.Server/Services/YoutubeIndexingService.cs
+++ b/source/Tubeshade.Server/Services/YoutubeIndexingService.cs
@@ -304,7 +304,6 @@ public sealed class YoutubeIndexingService
                 format,
                 cookieFilepath,
                 preferences.PlayerClient,
-                availability != ExternalAvailability.Public,
                 cancellationToken);
 
             if (data.Formats is null or [])

--- a/source/Tubeshade.Server/Services/YtdlpWrapper.cs
+++ b/source/Tubeshade.Server/Services/YtdlpWrapper.cs
@@ -118,13 +118,12 @@ public sealed class YtdlpWrapper : IYtdlpWrapper
         string format,
         string? cookieFilepath,
         PlayerClient? client,
-        bool ignoreNoFormatsError,
         CancellationToken cancellationToken)
     {
         var optionSet = GetDefaultOptions(cookieFilepath);
         optionSet.Format = format;
         optionSet.EmbedChapters = true;
-        optionSet.IgnoreNoFormatsError = ignoreNoFormatsError;
+        optionSet.IgnoreNoFormatsError = true;
         optionSet.DumpSingleJson = true;
         optionSet.ExtractorArgs = client is not null
             ? new MultiValue<string>($"youtube:player_client={client.Name}")


### PR DESCRIPTION
When a video is blocked on copyright grounds, it's not indicated any way in the standard error output