### PR TITLE
Include unique id in the thumbnail file name

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,8 @@ _Latest build from master branch._
   ([#311](https://github.com/Tubeshade/Tubeshade/pull/311))
 - Downloading thumbnails for videos without available formats
   ([#311](https://github.com/Tubeshade/Tubeshade/pull/311))
+- Correctly link thumbnails when indexing multiple videos
+  ([#312](https://github.com/Tubeshade/Tubeshade/pull/312))
 
 ## [0.1.7] - 2026-07-17
 

--- a/source/Tubeshade.Server/Services/IYtdlpWrapper.cs
+++ b/source/Tubeshade.Server/Services/IYtdlpWrapper.cs
@@ -43,6 +43,7 @@ public interface IYtdlpWrapper
 
     ValueTask DownloadThumbnails(
         string url,
+        string prefix,
         string path,
         string? cookieFilepath,
         CancellationToken cancellationToken);

--- a/source/Tubeshade.Server/Services/YoutubeIndexingService.cs
+++ b/source/Tubeshade.Server/Services/YoutubeIndexingService.cs
@@ -504,15 +504,18 @@ public sealed class YoutubeIndexingService
         }
 
         _logger.DownloadingThumbnails();
-        await _ytdlpWrapper.DownloadThumbnails(url, directory.FullName, cookieFilepath, cancellationToken);
+        var fileNamePrefix = $"thumbnail_{video.Id:N}";
+        await _ytdlpWrapper.DownloadThumbnails(url, fileNamePrefix, directory.FullName, cookieFilepath, cancellationToken);
 
         var files =  thumbnails
             .SelectMany(thumbnail =>
             {
-                var files = directory.EnumerateFiles($"thumbnail.{thumbnail.Id}.*").ToArray();
+                var pattern = $"{fileNamePrefix}.{thumbnail.Id}.*";
+                var files = directory.EnumerateFiles(pattern).ToArray();
                 if (files.Length > 1)
                 {
-                    throw new Exception("Multiple images");
+                    var fileNames = string.Join(", ", files.Select(file => $"'{file.Name}'"));
+                    throw new Exception($"Found multiple image files matching the pattern {pattern}: {fileNames}");
                 }
 
                 if (files is [])
@@ -587,8 +590,11 @@ public sealed class YoutubeIndexingService
         }
 
         _logger.DownloadingThumbnails();
+
+        var fileNamePrefix = $"thumbnail_{channel.Id:N}";
         await _ytdlpWrapper.DownloadThumbnails(
             channel.ExternalUrl,
+            fileNamePrefix,
             channel.StoragePath,
             cookieFilepath,
             cancellationToken);
@@ -597,11 +603,13 @@ public sealed class YoutubeIndexingService
 
         foreach (var thumbnail in videoData.Thumbnails ?? [])
         {
-            var file = directory.EnumerateFiles($"thumbnail.{thumbnail.Id}.*").ToArray() switch
+            var pattern = $"{fileNamePrefix}.{thumbnail.Id}.*";
+            var file = directory.EnumerateFiles(pattern).ToArray() switch
             {
-                [] => throw new Exception("Could not find downloaded image"),
+                [] => throw new Exception($"Could not find downloaded image for {thumbnail.Id} ({thumbnail.Url})"),
                 [var singleFile] => singleFile,
-                _ => throw new Exception("Multiple images"),
+                var files => throw new Exception(
+                    $"Found multiple image files matching the pattern {pattern}: {string.Join(", ", files.Select(file => $"'{file.Name}'"))}"),
             };
 
             var hashAlgorithm = HashAlgorithm.Default;

--- a/source/Tubeshade.Server/Services/YtdlpWrapper.cs
+++ b/source/Tubeshade.Server/Services/YtdlpWrapper.cs
@@ -206,12 +206,13 @@ public sealed class YtdlpWrapper : IYtdlpWrapper
     /// <inheritdoc />
     public async ValueTask DownloadThumbnails(
         string url,
+        string prefix,
         string path,
         string? cookieFilepath,
         CancellationToken cancellationToken)
     {
         var optionSet = GetDefaultOptions(cookieFilepath);
-        optionSet.Output = "thumbnail.%(ext)s";
+        optionSet.Output = $"{prefix}.%(ext)s";
         optionSet.Paths = path;
         optionSet.SkipDownload = true;
         optionSet.IgnoreNoFormatsError = true;


### PR DESCRIPTION
When indexing multiple videos, the task directory might contain thumbnails from previous videos
