### PR TITLE
Add option to disable post checks for webhooks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,8 @@ _Latest build from master branch._
   ([#38](https://github.com/Tubeshade/Tubeshade/issues/38))
 - Next/previous track actions control video chapters
   ([#316](https://github.com/Tubeshade/Tubeshade/pull/316))
+- Option to disable post check for webhooks
+  ([#320](https://github.com/Tubeshade/Tubeshade/pull/320))
 
 ### Changed
 

--- a/source/Tubeshade.Server/Configuration/WebhookOptions.cs
+++ b/source/Tubeshade.Server/Configuration/WebhookOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Tubeshade.Server.Configuration;
+
+public sealed class WebhookOptions
+{
+    public const string SectionName = "Webhook";
+
+    public bool CheckForPosts { get; set; } = true;
+}

--- a/source/Tubeshade.Server/Program.cs
+++ b/source/Tubeshade.Server/Program.cs
@@ -52,6 +52,11 @@ internal static class Program
             .BindConfiguration(SchedulerOptions.SectionName)
             .ValidateOnStart();
 
+        builder.Services
+            .AddOptions<WebhookOptions>()
+            .BindConfiguration(WebhookOptions.SectionName)
+            .ValidateOnStart();
+
         builder.Services.AddRazorPages();
 
         builder.Services.AddAuthenticationAndAuthorization(builder.Configuration);

--- a/source/Tubeshade.Server/Services/YoutubePostChecker.cs
+++ b/source/Tubeshade.Server/Services/YoutubePostChecker.cs
@@ -20,6 +20,19 @@ public sealed class YoutubePostChecker
         _httpClient = httpClient;
     }
 
+    public async ValueTask<bool> IsYouTubePost2(string videoUrl, CancellationToken cancellationToken)
+    {
+        if (await IsYouTubePost(videoUrl, cancellationToken))
+        {
+            return true;
+        }
+
+        // posts cannot be identified immediately after receiving the notification, retry a moment later
+        await Task.Delay(5_000, cancellationToken);
+
+        return await IsYouTubePost(videoUrl, cancellationToken);
+    }
+
     public async ValueTask<bool> IsYouTubePost(string videoUrl, CancellationToken cancellationToken)
     {
         if (!Uri.TryCreate(videoUrl, UriKind.Absolute, out var uri))

--- a/source/Tubeshade.Server/Services/YoutubeWebhookService.cs
+++ b/source/Tubeshade.Server/Services/YoutubeWebhookService.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using NodaTime;
 using Npgsql;
 using PubSubHubbub.Models;
@@ -14,6 +15,7 @@ using Tubeshade.Data.AccessControl;
 using Tubeshade.Data.Media.Videos;
 using Tubeshade.Data.Preferences;
 using Tubeshade.Data.Tasks;
+using Tubeshade.Server.Configuration;
 using YoutubeDLSharp.Metadata;
 
 namespace Tubeshade.Server.Services;
@@ -23,6 +25,7 @@ public sealed class YoutubeWebhookService
     private static readonly XmlSerializer FeedSerializer = new(typeof(Feed));
 
     private readonly ILogger<YoutubeWebhookService> _logger;
+    private readonly IOptionsMonitor<WebhookOptions> _options;
     private readonly NpgsqlConnection _connection;
     private readonly VideoRepository _videoRepository;
     private readonly PreferencesRepository _preferencesRepository;
@@ -34,6 +37,7 @@ public sealed class YoutubeWebhookService
 
     public YoutubeWebhookService(
         ILogger<YoutubeWebhookService> logger,
+        IOptionsMonitor<WebhookOptions> options,
         NpgsqlConnection connection,
         VideoRepository videoRepository,
         PreferencesRepository preferencesRepository,
@@ -44,6 +48,7 @@ public sealed class YoutubeWebhookService
         IClock clock)
     {
         _logger = logger;
+        _options = options;
         _connection = connection;
         _videoRepository = videoRepository;
         _preferencesRepository = preferencesRepository;
@@ -135,18 +140,13 @@ public sealed class YoutubeWebhookService
             return;
         }
 
-        if (await _postChecker.IsYouTubePost(videoUrl, cancellationToken))
+        if (_options.CurrentValue.CheckForPosts)
         {
-            _logger.SkippingPost();
-            return;
-        }
-
-        // posts cannot be identified immediately after receiving the notification, retry a moment later
-        await Task.Delay(5_000, cancellationToken);
-        if (await _postChecker.IsYouTubePost(videoUrl, cancellationToken))
-        {
-            _logger.SkippingPost();
-            return;
+            if (await _postChecker.IsYouTubePost2(videoUrl, cancellationToken))
+            {
+                _logger.SkippingPost();
+                return;
+            }
         }
 
         switch (preferences)


### PR DESCRIPTION
This check hasn't caught any posts recently, so it could be that it just introduces unnecessary delays